### PR TITLE
Add latency performance data

### DIFF
--- a/check_smb_file.pl
+++ b/check_smb_file.pl
@@ -340,8 +340,8 @@ sub showOutputAndExit {
         $output .= '|';
         while (my ($key, $value) = each(%PERF_DATA)) {
             $output .= "'" . $$value{'LABEL'} . "'=" . $$value{'VALUE'}.$$value{'UOM'}
-             . " 'latency'=". $$value{'LATENCY'} . "s"
-             . ';' . $$value{'WARN'} . ';' . $$value{'CRIT'} . ";;";
+             . ';' . $$value{'WARN'} . ';' . $$value{'CRIT'} . ";;"
+             . " 'latency'=". $$value{'LATENCY'} . "s;;;;";
         }
     }
     print $output . "\n";


### PR DESCRIPTION
Adds a 'latency' parameter to the performance data returned to nagios. Useful for seeing if there is a degradation in performance. Requires Time::HiRes.
