### PR TITLE
Ignore . and .. dir

### DIFF
--- a/check_smb_file.pl
+++ b/check_smb_file.pl
@@ -539,6 +539,7 @@ if ($o_filename_match || $o_mode_directory) {
     }
     foreach my $filename ($smb->readdir($fd)) {
         my $full_filename = "$full_file_path/$filename";
+        if($filename eq "." || $filename eq ".."){ next;}
         if (($o_filename_match and !$o_match_case) and $filename =~ m/$o_filename_match/i) {
             $directory_files{"$o_filepath/$filename"} = \@{ getFileStat($full_filename, $smb) };
         }


### PR DESCRIPTION
if($filename eq "." || $filename eq ".."){ next;}


Without this line file check will always show 2 "files" that are not files. 